### PR TITLE
#161968680 Change order destination

### DIFF
--- a/app/api/v2/__init__.py
+++ b/app/api/v2/__init__.py
@@ -3,7 +3,7 @@ from flask import Blueprint
 from flask_restful import Api
 from .views.user_views import UserRegistration, UserLogin
 from .views.parcel_views import (
-    ParcelOrderView, UserOrderView, AllOrdersView, StatusView)
+    ParcelOrderView, UserOrderView, AllOrdersView, StatusView, DestinationView)
 
 version_2 = Blueprint('apiv2', __name__)
 
@@ -14,3 +14,4 @@ api.add_resource(ParcelOrderView, "/parcels")
 api.add_resource(UserOrderView, "/parcels/<string:username>")
 api.add_resource(AllOrdersView, "/parcels")
 api.add_resource(StatusView, "/parcels/<int:parcel_id>/status")
+api.add_resource(DestinationView, "/parcels/<int:parcel_id>/destination")

--- a/app/api/v2/models/parcel_models.py
+++ b/app/api/v2/models/parcel_models.py
@@ -74,3 +74,22 @@ class ParcelOrder(object):
             (status, parcel_id,))
         self.database.commit()
         return {"message": "status changed successfully"}
+
+    def change_destination(self, parcel_id):
+        """Docstring for change destination."""
+        parser = reqparse.RequestParser()
+        parser.add_argument("destination", type=str,
+                            help="destination is missing", required=True)
+        destination = parser.parse_args()["destination"]
+        if not CheckUserInput().check_if_input_is_string(destination):
+            return {"message": "Please enter a valid name"}
+        cur = self.database.cursor()
+        parcel = self.get_parcel_by_id(parcel_id)
+        if not parcel:
+            return {"message": "No parcel order made"}
+        else:
+            cur.execute(
+                """UPDATE orders SET destination = (%s)
+                WHERE parcel_id = (%s);""", (destination, parcel_id))
+            self.database.commit()
+            return {"message": "destination changed successfully"}

--- a/app/api/v2/views/parcel_views.py
+++ b/app/api/v2/views/parcel_views.py
@@ -108,3 +108,29 @@ class StatusView(Resource, ParcelOrder):
 
         else:
             return {"message": "user or parcel does not exist"}, 404
+
+
+class DestinationView(Resource, ParcelOrder):
+    """docstring for DestinationView."""
+
+    @jwt_required
+    def put(self, parcel_id):
+        """Docstring for put method."""
+        user_id = get_jwt_identity()
+        user = UserModel().get_user_by_id(user_id)
+        parcel = ParcelOrder().get_parcel_by_id(parcel_id)
+
+        if user and parcel:
+            if user_id == parcel[1]:
+                if parcel[8] == "not_delivered":
+                    new = ParcelOrder().change_destination(parcel_id)
+                    return make_response(jsonify(new), 200)
+                else:
+                    return {
+                        "message": "Destination cannot be changed since parcel is in transit"}, 400
+            else:
+                return {
+                    "message": "You have no access rights to change parcel order"}, 403
+
+        else:
+            return {"message": "user or parcel does not exist"}, 404


### PR DESCRIPTION
#### What does this PR do?
Creates a feature branch for changing the destination of a parcel delivery order
#### Description of Task to be completed?
User should be able to change the destination of a parcel delivery order that they made, no other user should be able change the destination of  another user's parcel
#### How should this be manually tested?
Clone this repo, cd into it, in terminal type: source .env && flask run. Then navigate to Postman and input the destination using the following API:
PUT api/v2/parcels/parcel_id/destination
#### What are the relevant pivotal tracker stories?
#161968680
#### Screenshots (if appropriate)
![destination](https://user-images.githubusercontent.com/11003992/48953392-c704b300-ef56-11e8-9a18-a2694de1d4bb.png)


